### PR TITLE
Improve backend auth redirect configuration

### DIFF
--- a/packages/backend/src/auth/GoogleAuth/auth.controller.ts
+++ b/packages/backend/src/auth/GoogleAuth/auth.controller.ts
@@ -1,49 +1,80 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Logger, Req, Res, UseGuards } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { GoogleOAuthGuard } from '../GoogleAuth/guard/google-oauth.guard';
 import { SessionAuthGuard } from '../GoogleAuth/guard/session-auth.guard';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('auth')
 export class AuthController {
-	@Get('google')
-	@UseGuards(GoogleOAuthGuard)
-	googleAuth() {
-		// редирект на Google
-	}
+        private readonly logger = new Logger(AuthController.name);
+        private readonly successRedirectUrl: string;
+        private readonly failureRedirectUrl: string;
+        private readonly logoutRedirectUrl: string;
+        private readonly sessionCookieName: string;
+        private readonly sessionCookieDomain?: string;
 
-	@Get('google/callback')
-	@UseGuards(GoogleOAuthGuard)
-	async googleAuthRedirect(@Req() req: Request, @Res() res: Response) {
-		// req.user уже есть после авторизации через Google
-		console.log('google callback req.user =', (req as any).user);
-		const user = (req as any).user;
+        constructor(private readonly configService: ConfigService) {
+                const frontendBaseUrl = this.configService.get<string>('FRONTEND_BASE_URL');
+                const defaultFrontendUrl = frontendBaseUrl || 'http://localhost:5173';
 
-		return new Promise((resolve) => {
-			(req as any).logIn(user, (err: any) => {
-				if (err) {
-					console.error('req.logIn error', err);
-					res.redirect('http://localhost:5173/auth/profile');
-					return resolve(null);
-				}
-				// сохраняем сессию перед редиректом
-				req.session.save((saveErr: any) => {
-					if (saveErr) console.error('session save error', saveErr);
-					console.log(
-						'session saved, session.passport =',
-						(req as any).session?.passport,
-					);
-					res.redirect('http://localhost:5173/auth/profile');
-					return resolve(null);
-				});
-			});
-		});
-	}
+                this.successRedirectUrl =
+                        this.configService.get<string>('AUTH_SUCCESS_REDIRECT') ||
+                        `${defaultFrontendUrl}/auth/profile`;
+                this.failureRedirectUrl =
+                        this.configService.get<string>('AUTH_FAILURE_REDIRECT') ||
+                        `${defaultFrontendUrl}/auth/profile?error=oauth`;
+                this.logoutRedirectUrl =
+                        this.configService.get<string>('AUTH_LOGOUT_REDIRECT') ||
+                        defaultFrontendUrl;
+                this.sessionCookieName =
+                        this.configService.get<string>('SESSION_COOKIE_NAME') || 'connect.sid';
+                this.sessionCookieDomain = this.configService.get<string>('SESSION_COOKIE_DOMAIN') || undefined;
+        }
 
-	@Get('profile')
-	@UseGuards(SessionAuthGuard)
-	getProfile(@Req() req: Request) {
-		return req.user;
-	}
+        @Get('google')
+        @UseGuards(GoogleOAuthGuard)
+        googleAuth() {
+                // редирект на Google
+        }
+
+        @Get('google/callback')
+        @UseGuards(GoogleOAuthGuard)
+        async googleAuthRedirect(@Req() req: Request, @Res() res: Response) {
+                // req.user уже есть после авторизации через Google
+                this.logger.debug(
+                        'google callback req.user = ' +
+                                (req.user ? (req.user as any).email || 'present' : 'missing'),
+                );
+
+                if (!req.user) {
+                        this.logger.warn('Google callback called without authenticated user');
+                        return res.redirect(this.failureRedirectUrl);
+                }
+
+                try {
+                        await new Promise<void>((resolve, reject) =>
+                                req.logIn(req.user as any, (err) => (err ? reject(err) : resolve())),
+                        );
+
+                        await new Promise<void>((resolve, reject) =>
+                                req.session.save((err: any) => (err ? reject(err) : resolve())),
+                        );
+
+                        this.logger.debug(
+                                'session saved, session id = ' + (req.sessionID || 'unknown'),
+                        );
+                        return res.redirect(this.successRedirectUrl);
+                } catch (err) {
+                        this.logger.error('Failed to finish Google auth callback flow', err as Error);
+                        return res.redirect(this.failureRedirectUrl);
+                }
+        }
+
+        @Get('profile')
+        @UseGuards(SessionAuthGuard)
+        getProfile(@Req() req: Request) {
+                return req.user;
+        }
 
 	// Diagnostic endpoint: returns req.user and session info (no guard)
 	// @Get('session-check')
@@ -73,10 +104,38 @@ export class AuthController {
 	// 	return { ok: true, user: (req as any).user };
 	// }
 
-	@Get('logout')
-	logout(@Req() req: Request, @Res() res: Response) {
-		req.logout(() => {});
-		req.session.destroy(() => {});
-		return res.redirect('http://localhost:5173');
-	}
+        @Get('logout')
+        async logout(@Req() req: Request, @Res() res: Response) {
+                try {
+                        await new Promise<void>((resolve, reject) =>
+                                req.logOut((err) => (err ? reject(err) : resolve())),
+                        );
+                } catch (err) {
+                        this.logger.error('Failed to log out user', err as Error);
+                }
+
+                if (req.session) {
+                        try {
+                                await new Promise<void>((resolve) =>
+                                        req.session.destroy((destroyErr) => {
+                                                if (destroyErr) {
+                                                        this.logger.error('Session destroy error', destroyErr as Error);
+                                                }
+                                                resolve();
+                                        }),
+                                );
+                        } catch (err) {
+                                this.logger.error('Unexpected error while destroying session', err as Error);
+                        }
+                } else {
+                        this.logger.warn('Logout requested without active session instance');
+                }
+
+                res.clearCookie(this.sessionCookieName, {
+                        domain: this.sessionCookieDomain,
+                        path: '/',
+                });
+
+                return res.redirect(this.logoutRedirectUrl);
+        }
 }

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -21,8 +21,11 @@ async function bootstrap() {
     credentials: true,
   });
 
+  const sessionCookieName = configService.get<string>('SESSION_COOKIE_NAME');
+
   app.use(
     session({
+      name: sessionCookieName || undefined,
       secret: configService.getOrThrow('SESSION_SECRET') || 'secret',
       resave: false,
       saveUninitialized: false,

--- a/packages/backend/src/types/express/index.d.ts
+++ b/packages/backend/src/types/express/index.d.ts
@@ -1,6 +1,8 @@
 import 'express';
 import 'express-session';
 
+type PassportCallback = (err: any, user?: Express.User, info?: any) => void;
+
 // Описываем структуру данных пользователя
 interface UserPayload {
 	id: string;
@@ -12,11 +14,15 @@ interface UserPayload {
 
 // Расширяем тип Request из Express
 declare module 'express-serve-static-core' {
-	interface Request {
-		user?: UserPayload; // Passport добавляет сюда пользователя
-		session: import('express-session').Session &
-			Partial<import('express-session').SessionData>;
-	}
+        interface Request {
+                user?: UserPayload; // Passport добавляет сюда пользователя
+                session: import('express-session').Session &
+                        Partial<import('express-session').SessionData>;
+                logIn: (user: Express.User, done: PassportCallback) => void;
+                login: (user: Express.User, done: PassportCallback) => void;
+                logOut: (done: (err?: any) => void) => void;
+                logout: (done: (err?: any) => void) => void;
+        }
 }
 
 // Расширяем интерфейс сессии


### PR DESCRIPTION
## Summary
- make Google OAuth redirects configurable and add defensive logging
to the NestJS auth controller
- harden logout/session teardown to clear cookies safely and surface
errors in logs
- expose passport login/logout helpers in the Express request typings
and allow configuring the session cookie name

## Testing
- pnpm --filter @go-with-me/backend build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ec6a8ee0832eaac1249e97556ebd)